### PR TITLE
feat: Paste to Upload/Post & Discover Page with Infinite Scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.8",
     "@emotion/server": "^11.10.0",
+    "@mantine/carousel": "^6.0.10",
     "@mantine/core": "^6.0.10",
     "@mantine/dropzone": "^6.0.10",
     "@mantine/form": "^6.0.10",
@@ -24,6 +25,7 @@
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.1",
     "axios": "^1.4.0",
+    "embla-carousel-react": "^8.0.0-rc03",
     "eslint": "8.39.0",
     "eslint-config-next": "13.3.4",
     "next": "13.3.4",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.8.0",
+    "react-query": "^3.39.3",
     "typescript": "5.0.4"
   }
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -16,7 +16,11 @@ import {
 import { IconCirclePlus, IconLogout } from "@tabler/icons-react";
 import Link from "next/link";
 
-function Header() {
+interface HeaderProps {
+  signupEnabled: boolean;
+}
+
+function Header({ signupEnabled }: HeaderProps) {
   const pb = usePocketBase();
   const { user } = useAuth();
   const { usernamePasswordEnabled } = useAuthMethods();
@@ -75,7 +79,7 @@ function Header() {
             >
               Login
             </Button>
-            {usernamePasswordEnabled && (
+            {usernamePasswordEnabled && signupEnabled && (
               <Button
                 radius="xl"
                 variant="outline"

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -28,9 +28,10 @@ import Header from "./header";
 
 interface LayoutProps {
   children?: React.ReactNode;
+  signupEnabled: boolean;
 }
 
-function Layout({ children }: LayoutProps) {
+function Layout({ children, signupEnabled }: LayoutProps) {
   const pb = usePocketBase();
   const { user } = useAuth();
 
@@ -52,7 +53,7 @@ function Layout({ children }: LayoutProps) {
   }, [user, setUserPosts, pb]);
 
   return (
-    <AppShell header={<Header />}>
+    <AppShell header={<Header signupEnabled={signupEnabled} />}>
       <Drawer
         opened={opened}
         onClose={close}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import { usePocketBase } from "@/pocketbase";
 import { useAuth } from "@/pocketbase/auth";
 import { Post } from "@/pocketbase/models";
+import { getRelativeTime } from "@/utils/relativeTime";
 import {
   ActionIcon,
   AppShell,
@@ -23,7 +24,6 @@ import Link from "next/link";
 import { Record } from "pocketbase";
 import React, { useEffect, useState } from "react";
 import { SlDrawer } from "react-icons/sl";
-import { getRelativeTime } from "@/utils/relativeTime";
 import Header from "./header";
 
 interface LayoutProps {
@@ -45,6 +45,7 @@ function Layout({ children }: LayoutProps) {
           filter: `author.id = "${user.id}"`,
           expand: "files,author",
           sort: "-created",
+          $autoCancel: false,
         });
         setUserPosts(records.items);
       })();

--- a/src/components/postCard.tsx
+++ b/src/components/postCard.tsx
@@ -1,0 +1,89 @@
+import { usePocketBase } from "@/pocketbase";
+import { Post } from "@/pocketbase/models";
+import {
+  Badge,
+  Box,
+  Card,
+  CardProps,
+  Center,
+  Image,
+  Text,
+  Title,
+} from "@mantine/core";
+import { IMAGE_MIME_TYPE } from "@mantine/dropzone";
+import Link from "next/link";
+import { Record } from "pocketbase";
+
+interface PostCardProps extends Omit<CardProps, "children"> {
+  post: Post;
+}
+
+function PostCard({ post, ...props }: PostCardProps) {
+  const pb = usePocketBase();
+
+  return (
+    <Card
+      key={post.id}
+      p={0}
+      {...props}
+      component={Link}
+      href={`/posts/${post.id}`}
+    >
+      <Card.Section p="md" pt={32} m={0}>
+        <Title order={4}>
+          {post.title || `Post by ${(post.expand.author as Record).username}`}
+        </Title>
+        {post.nsfw && <Badge color="red">NSFW</Badge>}
+      </Card.Section>
+      <Card.Section>
+        {Array.isArray(post.expand.files) && (
+          <Box pos="relative">
+            {IMAGE_MIME_TYPE.includes(post.expand.files[0].type) ? (
+              <Image
+                src={pb.files.getUrl(
+                  post.expand.files[0],
+                  post.expand.files[0].file
+                )}
+                sx={{ flex: 1 }}
+                alt={
+                  post.title ||
+                  `Post by ${(post.expand.author as Record).username}`
+                }
+              />
+            ) : (
+              <video
+                src={pb.files.getUrl(
+                  post.expand.files[0],
+                  post.expand.files[0].file
+                )}
+                muted
+                autoPlay
+                controls={false}
+              />
+            )}
+            {post.expand.files.length > 1 && (
+              <Box
+                pos="absolute"
+                sx={(theme) => ({
+                  background: theme.fn.rgba(theme.colors.dark[8], 0.7),
+                })}
+                top={0}
+                right={0}
+                bottom={0}
+                left={0}
+              >
+                <Center h="100%" w="100%">
+                  <Box>
+                    <Text size="xl">{post.expand.files.length - 1} +</Text>
+                  </Box>
+                </Center>
+              </Box>
+            )}
+          </Box>
+        )}
+      </Card.Section>
+    </Card>
+  );
+}
+
+export default PostCard;

--- a/src/components/postCard.tsx
+++ b/src/components/postCard.tsx
@@ -28,6 +28,9 @@ function PostCard({ post, ...props }: PostCardProps) {
       {...props}
       component={Link}
       href={`/posts/${post.id}`}
+      sx={(theme) => ({
+        ":hover": { background: theme.colors.dark[8] },
+      })}
     >
       <Card.Section p="md" pt={32} m={0}>
         <Title order={4}>

--- a/src/components/postCard.tsx
+++ b/src/components/postCard.tsx
@@ -1,18 +1,11 @@
 import { usePocketBase } from "@/pocketbase";
 import { Post } from "@/pocketbase/models";
-import {
-  Badge,
-  Box,
-  Card,
-  CardProps,
-  Center,
-  Image,
-  Text,
-  Title,
-} from "@mantine/core";
+import { Carousel } from "@mantine/carousel";
+import { Badge, Box, CardProps, Image, Paper, Title } from "@mantine/core";
 import { IMAGE_MIME_TYPE } from "@mantine/dropzone";
 import Link from "next/link";
 import { Record } from "pocketbase";
+import PostTitle from "./postTitle";
 
 interface PostCardProps extends Omit<CardProps, "children"> {
   post: Post;
@@ -22,7 +15,7 @@ function PostCard({ post, ...props }: PostCardProps) {
   const pb = usePocketBase();
 
   return (
-    <Card
+    <Paper
       key={post.id}
       p={0}
       {...props}
@@ -30,62 +23,37 @@ function PostCard({ post, ...props }: PostCardProps) {
       href={`/posts/${post.id}`}
       sx={(theme) => ({
         ":hover": { background: theme.colors.dark[8] },
+        overflow: "hidden",
       })}
+      bg="dark.6"
+      radius="md"
     >
-      <Card.Section p="md" pt={32} m={0}>
-        <Title order={4}>
-          {post.title || `Post by ${(post.expand.author as Record).username}`}
-        </Title>
-        {post.nsfw && <Badge color="red">NSFW</Badge>}
-      </Card.Section>
-      <Card.Section>
-        {Array.isArray(post.expand.files) && (
-          <Box pos="relative">
-            {IMAGE_MIME_TYPE.includes(post.expand.files[0].type) ? (
-              <Image
-                src={pb.files.getUrl(
-                  post.expand.files[0],
-                  post.expand.files[0].file
-                )}
-                sx={{ flex: 1 }}
-                alt={
-                  post.title ||
-                  `Post by ${(post.expand.author as Record).username}`
-                }
-              />
-            ) : (
-              <video
-                src={pb.files.getUrl(
-                  post.expand.files[0],
-                  post.expand.files[0].file
-                )}
-                muted
-                autoPlay
-                controls={false}
-              />
-            )}
-            {post.expand.files.length > 1 && (
-              <Box
-                pos="absolute"
-                sx={(theme) => ({
-                  background: theme.fn.rgba(theme.colors.dark[8], 0.7),
-                })}
-                top={0}
-                right={0}
-                bottom={0}
-                left={0}
-              >
-                <Center h="100%" w="100%">
-                  <Box>
-                    <Text size="xl">{post.expand.files.length - 1} +</Text>
-                  </Box>
-                </Center>
-              </Box>
-            )}
-          </Box>
-        )}
-      </Card.Section>
-    </Card>
+      <PostTitle post={post} p="md" />
+      <Carousel withIndicators onClickCapture={(ev) => ev.preventDefault()}>
+        {Array.isArray(post.expand.files) &&
+          post.expand.files.map((f) => (
+            <Carousel.Slide key={f.id}>
+              {IMAGE_MIME_TYPE.includes(f.type) ? (
+                <Image
+                  src={pb.files.getUrl(f, f.file)}
+                  sx={{ flex: 1 }}
+                  alt={
+                    post.title ||
+                    `Post by ${(post.expand.author as Record).username}`
+                  }
+                />
+              ) : (
+                <video
+                  src={pb.files.getUrl(f, f.file)}
+                  muted
+                  autoPlay
+                  controls={false}
+                />
+              )}
+            </Carousel.Slide>
+          ))}
+      </Carousel>
+    </Paper>
   );
 }
 

--- a/src/components/postTitle.tsx
+++ b/src/components/postTitle.tsx
@@ -1,0 +1,47 @@
+import { Post } from "@/pocketbase/models";
+import { getRelativeTime } from "@/utils/relativeTime";
+import {
+  Avatar,
+  Badge,
+  Box,
+  BoxProps,
+  Flex,
+  Group,
+  Text,
+  Title,
+  Tooltip,
+} from "@mantine/core";
+import { Record } from "pocketbase";
+
+interface PostTitleProps extends BoxProps {
+  post: Post;
+  compact?: boolean;
+}
+
+function PostTitle({ post, compact, ...props }: PostTitleProps) {
+  return (
+    <Box {...props}>
+      <Flex sx={{ justifyContent: "space-between" }} mb={compact ? 0 : "xs"}>
+        <Tooltip
+          label={new Date(post.created).toLocaleString()}
+          color="dark"
+          zIndex={1100}
+        >
+          <Text color="gray.6" size="sm">
+            {getRelativeTime(new Date(), new Date(post.created))}
+          </Text>
+        </Tooltip>
+        <Group spacing="sm">
+          <Text size="sm">{(post.expand.author as Record).username}</Text>
+          <Avatar radius="xl" size="sm"></Avatar>
+        </Group>
+      </Flex>
+      <Title order={4}>
+        {post.title || `Post by ${(post.expand.author as Record).username}`}
+      </Title>
+      {post.nsfw && <Badge color="red">NSFW</Badge>}
+    </Box>
+  );
+}
+
+export default PostTitle;

--- a/src/hooks/useAuthMethods.ts
+++ b/src/hooks/useAuthMethods.ts
@@ -11,7 +11,9 @@ export const useAuthMethods = () => {
   useEffect(() => {
     (async () => {
       try {
-        const authMethods = await pb.collection("users").listAuthMethods();
+        const authMethods = await pb
+          .collection("users")
+          .listAuthMethods({ $autoCancel: false });
         setAuthProviders(authMethods.authProviders);
         setUsernamePasswordEnabled(
           authMethods.usernamePassword || authMethods.emailPassword

--- a/src/hooks/useAuthMethods.ts
+++ b/src/hooks/useAuthMethods.ts
@@ -10,11 +10,15 @@ export const useAuthMethods = () => {
 
   useEffect(() => {
     (async () => {
-      const authMethods = await pb.collection("users").listAuthMethods();
-      setAuthProviders(authMethods.authProviders);
-      setUsernamePasswordEnabled(
-        authMethods.usernamePassword || authMethods.emailPassword
-      );
+      try {
+        const authMethods = await pb.collection("users").listAuthMethods();
+        setAuthProviders(authMethods.authProviders);
+        setUsernamePasswordEnabled(
+          authMethods.usernamePassword || authMethods.emailPassword
+        );
+      } catch (ex) {
+        console.error(ex);
+      }
     })();
   }, [pb, setAuthProviders, setUsernamePasswordEnabled]);
 

--- a/src/hooks/useCreatePost.ts
+++ b/src/hooks/useCreatePost.ts
@@ -1,0 +1,41 @@
+import { usePocketBase } from "@/pocketbase";
+import { NewFile, useUploadFiles } from "./useUploadFiles";
+
+interface NewPost {
+  author: string;
+  title: string;
+  files: NewFile[];
+  public?: boolean;
+  nsfw?: boolean;
+}
+
+interface UseCreatePostOptions {
+  acceptTypes: string[];
+}
+
+export const useCreatePost = ({ acceptTypes }: UseCreatePostOptions) => {
+  const pb = usePocketBase();
+
+  const { uploadFiles, uploading } = useUploadFiles({
+    acceptTypes,
+  });
+
+  const createPost = (newPost: NewPost) =>
+    uploadFiles(newPost.files).then(async (records) => {
+      if (records.length === 0) {
+        return;
+      }
+
+      const post = await pb.collection("posts").create({
+        title: newPost.title,
+        author: newPost.author,
+        files: records.map((f) => f.id),
+        public: newPost.public,
+        nsfw: newPost.nsfw,
+      });
+
+      return post;
+    });
+
+  return { uploading, createPost };
+};

--- a/src/hooks/usePasteFiles.tsx
+++ b/src/hooks/usePasteFiles.tsx
@@ -1,0 +1,45 @@
+import { notifications } from "@mantine/notifications";
+import { IconAlertCircle } from "@tabler/icons-react";
+import { useEffect, useRef } from "react";
+
+interface UsePasteFilesOptions {
+  acceptTypes: string[];
+  onPaste: (files: File[]) => void;
+}
+
+export const usePasteFiles = ({
+  acceptTypes,
+  onPaste,
+}: UsePasteFilesOptions) => {
+  const pasteListenerRef = useRef<(ev: ClipboardEvent) => void>();
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      pasteListenerRef.current &&
+        document.removeEventListener("paste", pasteListenerRef.current);
+
+      pasteListenerRef.current = (ev) => {
+        if (!ev.clipboardData?.files.length) {
+          return;
+        }
+        const files = Array.from(ev.clipboardData.files);
+        if (files.filter((f) => !acceptTypes.includes(f.type)).length !== 0) {
+          notifications.show({
+            color: "red",
+            title: "An error occured",
+            message: "Please contact the developers",
+            icon: <IconAlertCircle />,
+          });
+          return;
+        }
+        onPaste(files);
+      };
+
+      document.addEventListener("paste", pasteListenerRef.current);
+
+      return () =>
+        pasteListenerRef.current &&
+        document.removeEventListener("paste", pasteListenerRef.current);
+    }
+  }, [onPaste, acceptTypes]);
+};

--- a/src/hooks/useUploadFiles.tsx
+++ b/src/hooks/useUploadFiles.tsx
@@ -5,14 +5,18 @@ import { IconAlertCircle } from "@tabler/icons-react";
 import { useState } from "react";
 import { usePocketBase } from "@/pocketbase";
 
-interface NewFile {
+export interface NewFile {
   file: File;
   name: string;
   author: string;
   description: string;
 }
 
-export const useUploadFiles = () => {
+interface UseUploadFilesOptions {
+  acceptTypes: string[];
+}
+
+export const useUploadFiles = ({ acceptTypes }: UseUploadFilesOptions) => {
   const pb = usePocketBase();
   const [uploading, setUploading] = useState(false);
 
@@ -20,6 +24,8 @@ export const useUploadFiles = () => {
     setUploading(true);
 
     const promises = files.map(async (file) => {
+      if (!acceptTypes.includes(file.file.type)) return;
+
       try {
         const createdRecord = await uploadFile(pb, {
           file: file.file,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,7 +16,7 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
-        <title>Page title</title>
+        <title>Share Me</title>
         <meta
           name="viewport"
           content="minimum-scale=1, initial-scale=1, width=device-width"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,9 @@ import { AppProps } from "next/app";
 import Head from "next/head";
 import PocketBase from "pocketbase";
 import { useRef } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }: AppProps) {
   const pbRef = useRef<PocketBase>(initPocketBase(pageProps.pocketBaseUrl));
@@ -29,11 +32,13 @@ export default function App({ Component, pageProps }: AppProps) {
         }}
       >
         <Notifications />
-        <PocketBaseProvider client={pbRef.current}>
-          <UploaderContextProvider pocketBase={pbRef.current}>
-            <Component {...pageProps} />
-          </UploaderContextProvider>
-        </PocketBaseProvider>
+        <QueryClientProvider client={queryClient}>
+          <PocketBaseProvider client={pbRef.current}>
+            <UploaderContextProvider pocketBase={pbRef.current}>
+              <Component {...pageProps} />
+            </UploaderContextProvider>
+          </PocketBaseProvider>
+        </QueryClientProvider>
       </MantineProvider>
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,56 +1,163 @@
 import Dropzone from "@/components/dropzone";
 import Head from "@/components/head";
 import Layout from "@/components/layout";
-import { useUploadFiles } from "@/hooks/useUploadFiles";
+import { useCreatePost } from "@/hooks/useCreatePost";
 import { pocketBaseUrl, usePocketBase } from "@/pocketbase";
 import { useAuth } from "@/pocketbase/auth";
-import { Group } from "@mantine/core";
-import { FileWithPath } from "@mantine/dropzone";
+import { MEDIA_MIME_TYPE } from "@/utils/mediaTypes";
+import {
+  Anchor,
+  Badge,
+  Box,
+  Card,
+  Center,
+  Container,
+  Flex,
+  Group,
+  Image,
+  ScrollArea,
+  Text,
+  Title,
+} from "@mantine/core";
+import { IMAGE_MIME_TYPE } from "@mantine/dropzone";
 import { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { Record } from "pocketbase";
+import { useEffect, useState } from "react";
+import { usePasteFiles } from "../hooks/usePasteFiles";
+import { Post } from "../pocketbase/models";
+import Link from "next/link";
 
 export default function Home() {
   const router = useRouter();
   const pb = usePocketBase();
   const { user } = useAuth();
 
-  const { uploading, uploadFiles: _uploadFiles } = useUploadFiles();
+  const [posts, setPosts] = useState<Post[]>([]);
 
   useEffect(() => {
-    if (!user) router.push("/login");
-  }, [user, router]);
+    pb.collection("posts")
+      .getList<Post>(1, 10, {
+        expand: "files,author",
+        sort: "-created",
+        $autoCancel: false,
+      })
+      .then((records) => setPosts(records.items));
+  }, [pb, setPosts]);
 
-  const uploadFiles = async (files: FileWithPath[]) =>
-    _uploadFiles(
-      files.map((file) => ({
+  const { uploading, createPost: _createPost } = useCreatePost({
+    acceptTypes: MEDIA_MIME_TYPE,
+  });
+
+  const createPost = (files: File[]) =>
+    _createPost({
+      title: "",
+      author: user?.id!,
+      files: files.map((file) => ({
         file: file,
         name: file.name,
         author: user?.id!,
         description: "",
-      }))
-    ).then(async (records) => {
-      if (records.length === 0) {
+      })),
+    }).then(async (post) => {
+      if (!post) {
         return;
       }
 
-      const post = await pb.collection("posts").create({
-        title: "",
-        author: user?.id!,
-        files: records.map((f) => f.id),
-        public: false,
-      });
-
       router.push("/posts/" + post.id);
     });
+
+  usePasteFiles({
+    acceptTypes: MEDIA_MIME_TYPE,
+    onPaste: createPost,
+  });
 
   return (
     <>
       <Head pageTitle="Upload" />
       <Layout>
-        <Group sx={{ justifyContent: "center" }} align="start">
-          <Dropzone onDrop={uploadFiles} loading={uploading} />
-        </Group>
+        <Container>
+          <Flex sx={{ justifyContent: "space-between" }}>
+            <Title order={2}>Latest Posts</Title>
+            <Anchor component={Link} href="/posts">
+              More
+            </Anchor>
+          </Flex>
+          <ScrollArea mb="lg" py="md">
+            <Group sx={{ flexWrap: "nowrap" }}>
+              {posts.map((post) => (
+                <Card key={post.id} p={0}>
+                  <Card.Section p="md" pt="lg" m={0}>
+                    <Title order={4}>
+                      {post.title ||
+                        `Post by ${(post.expand.author as Record).username}`}
+                    </Title>
+                    {post.nsfw && <Badge color="red">NSFW</Badge>}
+                  </Card.Section>
+                  <Card.Section>
+                    {Array.isArray(post.expand.files) && (
+                      <Box pos="relative">
+                        {IMAGE_MIME_TYPE.includes(post.expand.files[0].type) ? (
+                          <Image
+                            src={pb.files.getUrl(
+                              post.expand.files[0],
+                              post.expand.files[0].file
+                            )}
+                            sx={{ flex: 1 }}
+                            alt={
+                              post.title ||
+                              `Post by ${
+                                (post.expand.author as Record).username
+                              }`
+                            }
+                          />
+                        ) : (
+                          <video
+                            src={pb.files.getUrl(
+                              post.expand.files[0],
+                              post.expand.files[0].file
+                            )}
+                            muted
+                            autoPlay
+                            controls={false}
+                          />
+                        )}
+                        {post.expand.files.length > 1 && (
+                          <Box
+                            pos="absolute"
+                            sx={(theme) => ({
+                              background: theme.fn.rgba(
+                                theme.colors.dark[8],
+                                0.7
+                              ),
+                            })}
+                            top={0}
+                            right={0}
+                            bottom={0}
+                            left={0}
+                          >
+                            <Center h="100%" w="100%">
+                              <Box>
+                                <Text size="xl">
+                                  {post.expand.files.length - 1} +
+                                </Text>
+                              </Box>
+                            </Center>
+                          </Box>
+                        )}
+                      </Box>
+                    )}
+                  </Card.Section>
+                </Card>
+              ))}
+            </Group>
+          </ScrollArea>
+          {user && (
+            <Group sx={{ justifyContent: "center" }} align="start">
+              <Dropzone onDrop={createPost} loading={uploading} />
+            </Group>
+          )}
+        </Container>
       </Layout>
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -87,7 +87,7 @@ export default function Home() {
             <Group sx={{ flexWrap: "nowrap" }}>
               {posts.map((post) => (
                 <Card key={post.id} p={0}>
-                  <Card.Section p="md" pt="lg" m={0}>
+                  <Card.Section p="sm" pt={26} m={0}>
                     <Title order={4}>
                       {post.title ||
                         `Post by ${(post.expand.author as Record).username}`}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import Dropzone from "@/components/dropzone";
 import Head from "@/components/head";
 import Layout from "@/components/layout";
+import PostTitle from "@/components/postTitle";
 import { useCreatePost } from "@/hooks/useCreatePost";
 import { usePasteFiles } from "@/hooks/usePasteFiles";
 import { usePocketBase } from "@/pocketbase";
@@ -10,7 +11,6 @@ import { withEnv } from "@/utils/env";
 import { MEDIA_MIME_TYPE } from "@/utils/mediaTypes";
 import {
   Anchor,
-  Badge,
   Box,
   Card,
   Center,
@@ -99,13 +99,10 @@ export default function Home({ signupEnabled }: HomeProps) {
                   sx={(theme) => ({
                     ":hover": { background: theme.colors.dark[8] },
                   })}
+                  miw={300}
                 >
                   <Card.Section p="sm" pt={26} m={0}>
-                    <Title order={4}>
-                      {post.title ||
-                        `Post by ${(post.expand.author as Record).username}`}
-                    </Title>
-                    {post.nsfw && <Badge color="red">NSFW</Badge>}
+                    <PostTitle post={post} compact />
                   </Card.Section>
                   <Card.Section>
                     {Array.isArray(post.expand.files) && (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -69,7 +69,7 @@ export default function Home() {
 
   usePasteFiles({
     acceptTypes: MEDIA_MIME_TYPE,
-    onPaste: createPost,
+    onPaste: (files) => user && createPost(files),
   });
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -86,7 +86,15 @@ export default function Home() {
           <ScrollArea mb="lg" py="md">
             <Group sx={{ flexWrap: "nowrap" }}>
               {posts.map((post) => (
-                <Card key={post.id} p={0}>
+                <Card
+                  key={post.id}
+                  p={0}
+                  component={Link}
+                  href={`/posts/${post.id}`}
+                  sx={(theme) => ({
+                    ":hover": { background: theme.colors.dark[8] },
+                  })}
+                >
                   <Card.Section p="sm" pt={26} m={0}>
                     <Title order={4}>
                       {post.title ||

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,8 +2,11 @@ import Dropzone from "@/components/dropzone";
 import Head from "@/components/head";
 import Layout from "@/components/layout";
 import { useCreatePost } from "@/hooks/useCreatePost";
-import { pocketBaseUrl, usePocketBase } from "@/pocketbase";
+import { usePasteFiles } from "@/hooks/usePasteFiles";
+import { usePocketBase } from "@/pocketbase";
 import { useAuth } from "@/pocketbase/auth";
+import { Post } from "@/pocketbase/models";
+import { withEnv } from "@/utils/env";
 import { MEDIA_MIME_TYPE } from "@/utils/mediaTypes";
 import {
   Anchor,
@@ -21,14 +24,16 @@ import {
 } from "@mantine/core";
 import { IMAGE_MIME_TYPE } from "@mantine/dropzone";
 import { GetServerSideProps } from "next";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { Record } from "pocketbase";
 import { useEffect, useState } from "react";
-import { usePasteFiles } from "../hooks/usePasteFiles";
-import { Post } from "../pocketbase/models";
-import Link from "next/link";
 
-export default function Home() {
+interface HomeProps {
+  signupEnabled: boolean;
+}
+
+export default function Home({ signupEnabled }: HomeProps) {
   const router = useRouter();
   const pb = usePocketBase();
   const { user } = useAuth();
@@ -75,7 +80,7 @@ export default function Home() {
   return (
     <>
       <Head pageTitle="Upload" />
-      <Layout>
+      <Layout signupEnabled={signupEnabled}>
         <Container>
           <Flex sx={{ justifyContent: "space-between" }}>
             <Title order={2}>Latest Posts</Title>
@@ -173,6 +178,6 @@ export default function Home() {
 
 export const getServerSideProps: GetServerSideProps = async () => {
   return {
-    props: pocketBaseUrl({}),
+    props: withEnv({}),
   };
 };

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,5 +1,7 @@
+import Head from "@/components/head";
 import { useAuthMethods } from "@/hooks/useAuthMethods";
-import { pocketBaseUrl, usePocketBase } from "@/pocketbase";
+import { usePocketBase } from "@/pocketbase";
+import { withEnv } from "@/utils/env";
 import {
   Anchor,
   Box,
@@ -36,7 +38,6 @@ import {
   SiTwitch,
   SiTwitter,
 } from "react-icons/si";
-import Head from "@/components/head";
 
 const authProviderIcons: Record<string, JSX.Element> = {
   apple: <SiApple />,
@@ -63,7 +64,11 @@ interface LoginForm {
   password: string;
 }
 
-function Login() {
+interface LoginProps {
+  signupEnabled: boolean;
+}
+
+function Login({ signupEnabled }: LoginProps) {
   const pb = usePocketBase();
   const router = useRouter();
 
@@ -144,9 +149,11 @@ function Login() {
               ))}
               {usernamePasswordEnabled && (
                 <Group sx={{ justifyContent: "space-between" }}>
-                  <Anchor component={Link} href="/sign-up">
-                    Sign Up
-                  </Anchor>
+                  {signupEnabled && (
+                    <Anchor component={Link} href="/sign-up">
+                      Sign Up
+                    </Anchor>
+                  )}
                   <Button variant="gradient" type="submit">
                     Log In
                   </Button>
@@ -164,6 +171,6 @@ export default Login;
 
 export const getServerSideProps: GetServerSideProps = async () => {
   return {
-    props: pocketBaseUrl({}),
+    props: withEnv({}),
   };
 };

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -1,15 +1,13 @@
 import Dropzone from "@/components/dropzone";
 import Head from "@/components/head";
 import Layout from "@/components/layout";
+import { useCreatePost } from "@/hooks/useCreatePost";
 import { usePasteFiles } from "@/hooks/usePasteFiles";
 import { useUploadFiles } from "@/hooks/useUploadFiles";
-import {
-  initPocketBaseServer,
-  pocketBaseUrl,
-  usePocketBase,
-} from "@/pocketbase";
+import { initPocketBaseServer, usePocketBase } from "@/pocketbase";
 import { useAuth } from "@/pocketbase/auth";
 import { Post, File as ShareMeFile } from "@/pocketbase/models";
+import { withEnv } from "@/utils/env";
 import { MEDIA_MIME_TYPE } from "@/utils/mediaTypes";
 import {
   ActionIcon,
@@ -38,7 +36,6 @@ import { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 import { Record } from "pocketbase";
 import { useCallback, useEffect, useState } from "react";
-import { useCreatePost } from "../../hooks/useCreatePost";
 
 interface PostProps {
   title: string;
@@ -48,6 +45,7 @@ interface PostProps {
   userIsAuthor: boolean;
   image?: string | null;
   video?: string | null;
+  signupEnabled: boolean;
 }
 
 export default function Post(props: PostProps) {
@@ -212,7 +210,7 @@ export default function Post(props: PostProps) {
         twitterCard="summary_large_image"
       />
 
-      <Layout>
+      <Layout signupEnabled={props.signupEnabled}>
         <Group sx={{ justifyContent: "center" }} align="start">
           <Stack maw="650px" miw="350px" sx={{ flex: 1, flexGrow: 1 }} px="md">
             {userIsAuthor ? (
@@ -438,7 +436,7 @@ export const getServerSideProps: GetServerSideProps<PostProps> = async ({
   );
 
   return {
-    props: pocketBaseUrl({
+    props: withEnv({
       title: record.title,
       nsfw: record.nsfw,
       isPublic: record.public,

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -5,14 +5,20 @@ import { usePasteFiles } from "@/hooks/usePasteFiles";
 import { usePocketBase } from "@/pocketbase";
 import { useAuth } from "@/pocketbase/auth";
 import { Post } from "@/pocketbase/models";
+import { withEnv } from "@/utils/env";
 import { MEDIA_MIME_TYPE } from "@/utils/mediaTypes";
 import { Skeleton, Stack, Text } from "@mantine/core";
 import { useIntersection } from "@mantine/hooks";
+import { GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useInfiniteQuery } from "react-query";
 
-export default function Posts() {
+interface PostsProps {
+  signupEnabled: boolean;
+}
+
+export default function Posts({ signupEnabled }: PostsProps) {
   const router = useRouter();
   const pb = usePocketBase();
   const { user } = useAuth();
@@ -75,7 +81,7 @@ export default function Posts() {
   }, [isLoading, hasNextPage, entry, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <Layout>
+    <Layout signupEnabled={signupEnabled}>
       <Stack align="center">
         {data?.pages.map((p) => (
           <>
@@ -101,3 +107,9 @@ export default function Posts() {
     </Layout>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    props: withEnv({}),
+  };
+};

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,0 +1,69 @@
+import Layout from "@/components/layout";
+import PostCard from "@/components/postCard";
+import { usePocketBase } from "@/pocketbase";
+import { Post } from "@/pocketbase/models";
+import { Skeleton, Stack, Text } from "@mantine/core";
+import { useIntersection } from "@mantine/hooks";
+import { useEffect } from "react";
+import { useInfiniteQuery } from "react-query";
+
+export default function Posts() {
+  const pb = usePocketBase();
+  const {
+    isLoading,
+    error,
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery(
+    "posts",
+    ({ pageParam = 1 }) =>
+      pb.collection("posts").getList<Post>(pageParam, 20, {
+        expand: "files,author",
+        sort: "-created",
+        $autoCancel: false,
+      }),
+    {
+      getNextPageParam: (data) =>
+        data.page < data.totalPages ? data.page + 1 : null,
+    }
+  );
+
+  const { ref, entry } = useIntersection();
+
+  useEffect(() => {
+    entry &&
+      hasNextPage &&
+      !isFetchingNextPage &&
+      !isLoading &&
+      fetchNextPage();
+  }, [isLoading, hasNextPage, entry, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <Layout>
+      <Stack align="center">
+        {data?.pages.map((p) => (
+          <>
+            {p.items.map((p) => (
+              <PostCard key={p.id} post={p} maw={400} />
+            ))}
+          </>
+        ))}
+        {(isFetchingNextPage || isLoading) &&
+          new Array(10)
+            .fill(null)
+            .map((_, i) => (
+              <Skeleton key={i} height={200} width="100%" maw={400} ref={ref} />
+            ))}
+        {hasNextPage && (
+          <Skeleton height={200} width="100%" maw={400} ref={ref} />
+        )}
+        <Text>
+          Showing {data?.pages.reduce((p, c) => p + c.items.length, 0)} /{" "}
+          {data?.pages[0].totalItems} Posts
+        </Text>
+      </Stack>
+    </Layout>
+  );
+}

--- a/src/pages/sign-up.tsx
+++ b/src/pages/sign-up.tsx
@@ -1,6 +1,6 @@
 import Head from "@/components/head";
 import { useAuthMethods } from "@/hooks/useAuthMethods";
-import { usePocketBase } from "@/pocketbase";
+import { initPocketBaseServer, usePocketBase } from "@/pocketbase";
 import { withEnv } from "@/utils/env";
 import {
   Anchor,
@@ -121,10 +121,20 @@ function SignUp() {
 
 export default SignUp;
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
+  const pb = await initPocketBaseServer(req, res);
+
+  const authMethods = await pb
+    .collection("users")
+    .listAuthMethods({ $autoCancel: false });
+
   const props = withEnv({});
 
-  if (!props.signupEnabled) {
+  if (
+    !props.signupEnabled &&
+    !authMethods.usernamePassword &&
+    !authMethods.emailPassword
+  ) {
     return { notFound: true };
   }
 

--- a/src/pages/sign-up.tsx
+++ b/src/pages/sign-up.tsx
@@ -1,5 +1,7 @@
+import Head from "@/components/head";
 import { useAuthMethods } from "@/hooks/useAuthMethods";
-import { pocketBaseUrl, usePocketBase } from "@/pocketbase";
+import { usePocketBase } from "@/pocketbase";
+import { withEnv } from "@/utils/env";
 import {
   Anchor,
   Box,
@@ -15,7 +17,6 @@ import { GetServerSideProps } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
-import Head from "@/components/head";
 
 interface SignUpForm {
   email: string;
@@ -121,7 +122,13 @@ function SignUp() {
 export default SignUp;
 
 export const getServerSideProps: GetServerSideProps = async () => {
+  const props = withEnv({});
+
+  if (!props.signupEnabled) {
+    return { notFound: true };
+  }
+
   return {
-    props: pocketBaseUrl({}),
+    props,
   };
 };

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,11 @@
+import { pocketBaseUrl } from "../pocketbase";
+
+export const withEnv = <T>(
+  props: T
+): T & { signupEnabled: boolean; pocketbaseUrl?: string } =>
+  pocketBaseUrl({
+    ...props,
+    signupEnabled: process.env.SIGNUP_ENABLED
+      ? process.env.SIGNUP_ENABLED === "true"
+      : true,
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,6 +228,13 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@mantine/carousel@^6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@mantine/carousel/-/carousel-6.0.10.tgz#9bc8346601a1ea9c775afa19ceed5046696cd5d3"
+  integrity sha512-zYYNnGhsU8vXM37fyDg6jFmmPviE/yK5LfEn40VdAn0cLalELRrrgEvn4wp1u6N9rikp5TlHL6szH0zfJunomA==
+  dependencies:
+    "@mantine/utils" "6.0.10"
+
 "@mantine/core@^6.0.10":
   version "6.0.10"
   resolved "https://registry.yarnpkg.com/@mantine/core/-/core-6.0.10.tgz#51657b15fea8d0201033e1a182d636eaf35db3fd"
@@ -1110,6 +1117,24 @@ duplexer2@^0.1.2:
   integrity sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==
   dependencies:
     readable-stream "^2.0.2"
+
+embla-carousel-react@^8.0.0-rc03:
+  version "8.0.0-rc03"
+  resolved "https://registry.yarnpkg.com/embla-carousel-react/-/embla-carousel-react-8.0.0-rc03.tgz#92a5388fe9364974a9eafe0fb9153b88a6457368"
+  integrity sha512-PxxBdAUlUgPXqeoO7JRuG2l/axXBzSxjz6eYRw3ifzGW0maIBWkdVB5lLC8JSFmCDXI8R3ZaQuL5d7KFvJOkBw==
+  dependencies:
+    embla-carousel "8.0.0-rc03"
+    embla-carousel-reactive-utils "8.0.0-rc03"
+
+embla-carousel-reactive-utils@8.0.0-rc03:
+  version "8.0.0-rc03"
+  resolved "https://registry.yarnpkg.com/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.0.0-rc03.tgz#78dc390965d292ac1d080036435701e49064ffe4"
+  integrity sha512-m2ZaxmG0MBs9nFsA3vEz0ZUNiwJaoJM8f//ENe8ODM/rEIiHkSQ1fN90k3k2NX9JemcllYGqz/bmE5cMYGXjJQ==
+
+embla-carousel@8.0.0-rc03:
+  version "8.0.0-rc03"
+  resolved "https://registry.yarnpkg.com/embla-carousel/-/embla-carousel-8.0.0-rc03.tgz#fadbea5a699a1a791f3ba1b424f2ac0ca170c622"
+  integrity sha512-2goVwmTYZdGFcRejbYJlaC/iWDPv/VAsASE60uLQYLSKpuQRTxq/huu548OozLsH/2uSelVszvmzfinZnnk/iw==
 
 emoji-regex@^9.2.2:
   version "9.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,7 +35,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.7", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.7":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
   integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
@@ -770,7 +770,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-big-integer@^1.6.44:
+big-integer@^1.6.16, big-integer@^1.6.44:
   version "1.6.51"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
@@ -796,6 +796,20 @@ braces@^3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 buffer-from@~0.1.1:
   version "0.1.2"
@@ -1025,6 +1039,11 @@ detect-node-es@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2071,6 +2090,11 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.4.0.tgz#8b437dbe642daa95760400b602378ed8ffea8430"
   integrity sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2169,6 +2193,14 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -2186,6 +2218,11 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -2238,6 +2275,13 @@ multipipe@^1.0.2:
   dependencies:
     duplexer2 "^0.1.2"
     object-assign "^4.1.0"
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.3.4:
   version "3.3.6"
@@ -2357,6 +2401,11 @@ object.values@^1.1.6:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 once@^1.3.0:
   version "1.4.0"
@@ -2552,6 +2601,15 @@ react-property@2.0.0:
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
   integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
 
+react-query@^3.39.3:
+  version "3.39.3"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.3.tgz#4cea7127c6c26bdea2de5fb63e51044330b03f35"
+  integrity sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-remove-scroll-bar@^2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
@@ -2643,6 +2701,11 @@ regexp.prototype.flags@^1.4.3, regexp.prototype.flags@^1.5.0:
     define-properties "^1.2.0"
     functions-have-names "^1.2.3"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -2671,7 +2734,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3023,6 +3086,14 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 untildify@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Add a scrollable gallery of recent posts to the homepage.
- Add the `/posts` page with infinite scrolling showing all public posts.
- Implement paste to post on homepage and posts page.
- Implement paste to upload additional images on post page.
- Add support for `SIGNUP_ENABLED` environment variable to disable sign-up UI (closes #4).