### PR TITLE
feat: ✨ Full-Page Dropzone and Create Post Page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*           text=auto     # auto
+*           text=auto
 *.txt       text
-*.vcproj    text eol=crlf # windows line-endings
-*.sh        text eol=lf   # linux line-endings
+*.vcproj    text eol=crlf
+*.sh        text eol=lf

--- a/src/components/head.tsx
+++ b/src/components/head.tsx
@@ -2,7 +2,7 @@ import NextHead from "next/head";
 
 interface HeadProps {
   children?: React.ReactNode;
-  pageTitle: string;
+  pageTitle?: string;
   description?: string;
   url?: string;
   image?: string | null;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -15,6 +15,7 @@ import {
 } from "@mantine/core";
 import { IconCirclePlus, IconLogout } from "@tabler/icons-react";
 import Link from "next/link";
+import { useRouter } from "next/router";
 
 interface HeaderProps {
   signUpEnabled: boolean;
@@ -22,6 +23,8 @@ interface HeaderProps {
 
 function Header({ signUpEnabled }: HeaderProps) {
   const pb = usePocketBase();
+  const router = useRouter();
+
   const { user } = useAuth();
   const { usernamePasswordEnabled } = useAuthMethods();
 
@@ -47,14 +50,14 @@ function Header({ signUpEnabled }: HeaderProps) {
           </Title>
         </Anchor>
         <Box sx={{ flexGrow: 1 }} />
-        {user ? (
+        {user && router.asPath !== "/posts/create" ? (
           <Group>
             <Button
               radius="xl"
               variant="gradient"
               size="md"
               component={Link}
-              href="/"
+              href="/posts/create"
               leftIcon={<IconCirclePlus />}
             >
               <MediaQuery smallerThan="sm" styles={{ display: "none" }}>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -17,10 +17,10 @@ import { IconCirclePlus, IconLogout } from "@tabler/icons-react";
 import Link from "next/link";
 
 interface HeaderProps {
-  signupEnabled: boolean;
+  signUpEnabled: boolean;
 }
 
-function Header({ signupEnabled }: HeaderProps) {
+function Header({ signUpEnabled }: HeaderProps) {
   const pb = usePocketBase();
   const { user } = useAuth();
   const { usernamePasswordEnabled } = useAuthMethods();
@@ -79,7 +79,7 @@ function Header({ signupEnabled }: HeaderProps) {
             >
               Login
             </Button>
-            {usernamePasswordEnabled && signupEnabled && (
+            {usernamePasswordEnabled && signUpEnabled && (
               <Button
                 radius="xl"
                 variant="outline"

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -28,10 +28,10 @@ import Header from "./header";
 
 interface LayoutProps {
   children?: React.ReactNode;
-  signupEnabled: boolean;
+  signUpEnabled: boolean;
 }
 
-function Layout({ children, signupEnabled }: LayoutProps) {
+function Layout({ children, signUpEnabled }: LayoutProps) {
   const pb = usePocketBase();
   const { user } = useAuth();
 
@@ -53,7 +53,7 @@ function Layout({ children, signupEnabled }: LayoutProps) {
   }, [user, setUserPosts, pb]);
 
   return (
-    <AppShell header={<Header signupEnabled={signupEnabled} />}>
+    <AppShell header={<Header signUpEnabled={signUpEnabled} />}>
       <Drawer
         opened={opened}
         onClose={close}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -17,23 +17,30 @@ import {
   Text,
   Title,
   Tooltip,
+  useMantineTheme,
 } from "@mantine/core";
 import { IMAGE_MIME_TYPE } from "@mantine/dropzone";
 import { useDisclosure } from "@mantine/hooks";
 import Link from "next/link";
 import { Record } from "pocketbase";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { SlDrawer } from "react-icons/sl";
 import Header from "./header";
+import { usePasteFiles } from "../hooks/usePasteFiles";
+import { MEDIA_MIME_TYPE } from "../utils/mediaTypes";
+import { IconPhotoPlus } from "@tabler/icons-react";
 
 interface LayoutProps {
   children?: React.ReactNode;
   signUpEnabled: boolean;
+  onFiles?: (files: File[]) => void;
 }
 
-function Layout({ children, signUpEnabled }: LayoutProps) {
+function Layout({ children, signUpEnabled, onFiles }: LayoutProps) {
   const pb = usePocketBase();
   const { user } = useAuth();
+
+  const theme = useMantineTheme();
 
   const [opened, { toggle, close }] = useDisclosure(false);
 
@@ -51,6 +58,66 @@ function Layout({ children, signUpEnabled }: LayoutProps) {
         setUserPosts(records.items);
       })();
   }, [user, setUserPosts, pb]);
+
+  const [dragging, setDragging] = useState(false);
+
+  const dragEnterHandler = useRef<(ev: DragEvent) => void>();
+  const dragLeaveHandler = useRef<(ev: DragEvent) => void>();
+  const dragOverHandler = useRef<(ev: DragEvent) => void>();
+  const dropHandler = useRef<(ev: DragEvent) => void>();
+
+  useEffect(() => {
+    const unregister = () => {
+      dragEnterHandler.current &&
+        document.removeEventListener("dragenter", dragEnterHandler.current);
+      dragLeaveHandler.current &&
+        document.removeEventListener("dragleave", dragLeaveHandler.current);
+      dragOverHandler.current &&
+        document.removeEventListener("dragover", dragOverHandler.current);
+      dropHandler.current &&
+        document.removeEventListener("drop", dropHandler.current);
+    };
+
+    if (typeof document !== "undefined") {
+      if (!onFiles) {
+        unregister();
+        return;
+      }
+
+      dragEnterHandler.current = (ev) => {
+        ev.preventDefault();
+        setDragging(true);
+      };
+      document.addEventListener("dragenter", dragEnterHandler.current);
+      dragLeaveHandler.current = (ev) => {
+        ev.preventDefault();
+        setDragging(false);
+      };
+      document.addEventListener("dragleave", dragLeaveHandler.current);
+      dragOverHandler.current = (ev) => {
+        ev.preventDefault();
+      };
+      document.addEventListener("dragover", dragOverHandler.current);
+      dropHandler.current = (ev) => {
+        if (!ev.dataTransfer?.files) return;
+
+        ev.preventDefault();
+        setDragging(false);
+
+        const files = Array.from(ev.dataTransfer?.files);
+
+        onFiles(files);
+      };
+      document.addEventListener("drop", dropHandler.current);
+    }
+
+    return unregister;
+  }, [setDragging, onFiles]);
+
+  usePasteFiles({
+    acceptTypes: MEDIA_MIME_TYPE,
+    onPaste: (files) => onFiles?.(files),
+  });
 
   return (
     <AppShell header={<Header signUpEnabled={signUpEnabled} />}>
@@ -152,6 +219,53 @@ function Layout({ children, signUpEnabled }: LayoutProps) {
           ))}
         </Stack>
       </Drawer>
+      {dragging && (
+        <Box
+          top={0}
+          left={0}
+          pos="fixed"
+          sx={(theme) => ({
+            background: theme.fn.linearGradient(
+              170,
+              theme.fn.rgba(theme.colors.blue[3], 0.7),
+              theme.fn.rgba(theme.colors.blue[5], 0.7)
+            ),
+            zIndex: 1000,
+            pointerEvents: "none",
+          })}
+          w="100vw"
+          h="100vh"
+        >
+          <Center h="100%" w="100%">
+            <Box
+              mah={250}
+              maw={400}
+              sx={(theme) => ({
+                borderRadius: theme.radius.md,
+                border: `2px solid ${theme.colors.dark[3]}`,
+                borderStyle: "dashed",
+              })}
+              h="100%"
+              w="100%"
+            >
+              <Center
+                h="100%"
+                w="100%"
+                sx={(theme) => ({
+                  background: theme.fn.rgba(theme.colors.blue[1], 0.4),
+                })}
+              >
+                <Group>
+                  <IconPhotoPlus color={theme.colors.dark[4]} size={40} />
+                  <Text color="dark" size="lg">
+                    Drop files anywhere
+                  </Text>
+                </Group>
+              </Center>
+            </Box>
+          </Center>
+        </Box>
+      )}
       {children}
       {user && (
         <ActionIcon

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,10 +30,10 @@ import { Record } from "pocketbase";
 import { useEffect, useState } from "react";
 
 interface HomeProps {
-  signupEnabled: boolean;
+  signUpEnabled: boolean;
 }
 
-export default function Home({ signupEnabled }: HomeProps) {
+export default function Home({ signUpEnabled }: HomeProps) {
   const router = useRouter();
   const pb = usePocketBase();
   const { user } = useAuth();
@@ -80,7 +80,7 @@ export default function Home({ signupEnabled }: HomeProps) {
   return (
     <>
       <Head pageTitle="Upload" />
-      <Layout signupEnabled={signupEnabled}>
+      <Layout signUpEnabled={signUpEnabled}>
         <Container>
           <Flex sx={{ justifyContent: "space-between" }}>
             <Title order={2}>Latest Posts</Title>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,7 @@
-import Dropzone from "@/components/dropzone";
 import Head from "@/components/head";
 import Layout from "@/components/layout";
 import PostTitle from "@/components/postTitle";
 import { useCreatePost } from "@/hooks/useCreatePost";
-import { usePasteFiles } from "@/hooks/usePasteFiles";
 import { usePocketBase } from "@/pocketbase";
 import { useAuth } from "@/pocketbase/auth";
 import { Post } from "@/pocketbase/models";
@@ -50,7 +48,7 @@ export default function Home({ signUpEnabled }: HomeProps) {
       .then((records) => setPosts(records.items));
   }, [pb, setPosts]);
 
-  const { uploading, createPost: _createPost } = useCreatePost({
+  const { createPost: _createPost } = useCreatePost({
     acceptTypes: MEDIA_MIME_TYPE,
   });
 
@@ -72,15 +70,13 @@ export default function Home({ signUpEnabled }: HomeProps) {
       router.push("/posts/" + post.id);
     });
 
-  usePasteFiles({
-    acceptTypes: MEDIA_MIME_TYPE,
-    onPaste: (files) => user && createPost(files),
-  });
-
   return (
     <>
-      <Head pageTitle="Upload" />
-      <Layout signUpEnabled={signUpEnabled}>
+      <Head />
+      <Layout
+        signUpEnabled={signUpEnabled}
+        onFiles={(files) => user && createPost(files)}
+      >
         <Container>
           <Flex sx={{ justifyContent: "space-between" }}>
             <Title order={2}>Latest Posts</Title>
@@ -189,11 +185,6 @@ export default function Home({ signUpEnabled }: HomeProps) {
               ))}
             </Group>
           </ScrollArea>
-          {user && (
-            <Group sx={{ justifyContent: "center" }} align="start">
-              <Dropzone onDrop={createPost} loading={uploading} w="100%" />
-            </Group>
-          )}
         </Container>
       </Layout>
     </>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -65,10 +65,10 @@ interface LoginForm {
 }
 
 interface LoginProps {
-  signupEnabled: boolean;
+  signUpEnabled: boolean;
 }
 
-function Login({ signupEnabled }: LoginProps) {
+function Login({ signUpEnabled }: LoginProps) {
   const pb = usePocketBase();
   const router = useRouter();
 
@@ -149,7 +149,7 @@ function Login({ signupEnabled }: LoginProps) {
               ))}
               {usernamePasswordEnabled && (
                 <Group sx={{ justifyContent: "space-between" }}>
-                  {signupEnabled && (
+                  {signUpEnabled && (
                     <Anchor component={Link} href="/sign-up">
                       Sign Up
                     </Anchor>

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -2,7 +2,6 @@ import Dropzone from "@/components/dropzone";
 import Head from "@/components/head";
 import Layout from "@/components/layout";
 import { useCreatePost } from "@/hooks/useCreatePost";
-import { usePasteFiles } from "@/hooks/usePasteFiles";
 import { useUploadFiles } from "@/hooks/useUploadFiles";
 import { initPocketBaseServer, usePocketBase } from "@/pocketbase";
 import { useAuth } from "@/pocketbase/auth";
@@ -122,14 +121,6 @@ export default function Post(props: PostProps) {
       router.push("/posts/" + post.id);
     });
 
-  usePasteFiles({
-    acceptTypes: MEDIA_MIME_TYPE,
-    onPaste: (files) =>
-      post?.author === user?.id
-        ? uploadFiles(files)
-        : user?.id && createPost(files),
-  });
-
   useEffect(() => {
     setBlurred(files.map(() => nsfw));
   }, [nsfw, setBlurred, files]);
@@ -230,7 +221,14 @@ export default function Post(props: PostProps) {
         twitterCard="summary_large_image"
       />
 
-      <Layout signUpEnabled={props.signUpEnabled}>
+      <Layout
+        signUpEnabled={props.signUpEnabled}
+        onFiles={(files) =>
+          post?.author === user?.id
+            ? uploadFiles(files)
+            : user?.id && createPost(files)
+        }
+      >
         <Group sx={{ justifyContent: "center" }} align="start">
           <Stack maw="650px" miw="350px" sx={{ flex: 1, flexGrow: 1 }} px="md">
             {userIsAuthor ||

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -207,7 +207,9 @@ export default function Post(props: PostProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [post, debouncedTitle, isPublic, nsfw]);
 
-  const postTitle = post?.title || `Post by ${props.postAuthorUsername}`;
+  const postTitle =
+    (nsfw ? "[NSFW] " : "") + post?.title ||
+    `Post by ${props.postAuthorUsername}`;
   const description = `Shared by ${props.postAuthorUsername}`;
 
   return (

--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -49,7 +49,7 @@ interface PostProps {
   userIsAuthor: boolean;
   image?: string | null;
   video?: string | null;
-  signupEnabled: boolean;
+  signUpEnabled: boolean;
 }
 
 const queryParams = { expand: "author" };
@@ -230,7 +230,7 @@ export default function Post(props: PostProps) {
         twitterCard="summary_large_image"
       />
 
-      <Layout signupEnabled={props.signupEnabled}>
+      <Layout signUpEnabled={props.signUpEnabled}>
         <Group sx={{ justifyContent: "center" }} align="start">
           <Stack maw="650px" miw="350px" sx={{ flex: 1, flexGrow: 1 }} px="md">
             {userIsAuthor ||

--- a/src/pages/posts/create.tsx
+++ b/src/pages/posts/create.tsx
@@ -1,0 +1,92 @@
+import Dropzone from "@/components/dropzone";
+import Head from "@/components/head";
+import Layout from "@/components/layout";
+import { useCreatePost } from "@/hooks/useCreatePost";
+import { useAuth } from "@/pocketbase/auth";
+import { withEnv } from "@/utils/env";
+import { MEDIA_MIME_TYPE } from "@/utils/mediaTypes";
+import { Checkbox, Container, Group, Switch, TextInput } from "@mantine/core";
+import { GetServerSideProps } from "next";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+interface CreatePostProps {
+  signUpEnabled: boolean;
+}
+
+export default function CreatePost({ signUpEnabled }: CreatePostProps) {
+  const router = useRouter();
+  const { user } = useAuth();
+
+  useEffect(() => {
+    !user && router.push("/");
+  });
+
+  const [title, setTitle] = useState("");
+  const [isPublic, setIsPublic] = useState(false);
+  const [nsfw, setNsfw] = useState(false);
+
+  const { uploading, createPost: _createPost } = useCreatePost({
+    acceptTypes: MEDIA_MIME_TYPE,
+  });
+
+  const createPost = (files: File[]) =>
+    _createPost({
+      title,
+      nsfw,
+      public: isPublic,
+      author: user?.id!,
+      files: files.map((file) => ({
+        file: file,
+        name: file.name,
+        author: user?.id!,
+        description: "",
+      })),
+    }).then(async (post) => {
+      if (!post) {
+        return;
+      }
+
+      router.push("/posts/" + post.id);
+    });
+
+  return (
+    <Layout
+      signUpEnabled={signUpEnabled}
+      onFiles={(files) => createPost(files)}
+    >
+      <Head pageTitle="Create a Post" />
+      <Container>
+        <TextInput
+          placeholder="Give your Post a Unique Title"
+          size="xl"
+          variant="unstyled"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          my="md"
+        />
+        <Group sx={{ justifyContent: "center" }} align="start" mb="lg">
+          <Dropzone onDrop={createPost} loading={uploading} w="100%" />
+        </Group>
+        <Group>
+          <Switch
+            label="Public"
+            checked={isPublic}
+            onChange={(e) => setIsPublic(e.target.checked)}
+          />
+          <Checkbox
+            label="NSFW"
+            checked={nsfw}
+            onChange={(e) => setNsfw(e.target.checked)}
+          />
+        </Group>
+      </Container>
+    </Layout>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    props: withEnv({}),
+  };
+};

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,7 +1,6 @@
 import Layout from "@/components/layout";
 import PostCard from "@/components/postCard";
 import { useCreatePost } from "@/hooks/useCreatePost";
-import { usePasteFiles } from "@/hooks/usePasteFiles";
 import { usePocketBase } from "@/pocketbase";
 import { useAuth } from "@/pocketbase/auth";
 import { Post } from "@/pocketbase/models";
@@ -65,11 +64,6 @@ export default function Posts({ signUpEnabled }: PostsProps) {
       router.push("/posts/" + post.id);
     });
 
-  usePasteFiles({
-    acceptTypes: MEDIA_MIME_TYPE,
-    onPaste: (files) => user && createPost(files),
-  });
-
   const { ref, entry } = useIntersection();
 
   useEffect(() => {
@@ -81,7 +75,10 @@ export default function Posts({ signUpEnabled }: PostsProps) {
   }, [isLoading, hasNextPage, entry, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <Layout signUpEnabled={signUpEnabled}>
+    <Layout
+      signUpEnabled={signUpEnabled}
+      onFiles={(files) => user && createPost(files)}
+    >
       <Stack align="stretch" maw={450} m="0 auto">
         {data?.pages.map((p) => (
           <>

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -15,10 +15,10 @@ import { useEffect } from "react";
 import { useInfiniteQuery } from "react-query";
 
 interface PostsProps {
-  signupEnabled: boolean;
+  signUpEnabled: boolean;
 }
 
-export default function Posts({ signupEnabled }: PostsProps) {
+export default function Posts({ signUpEnabled }: PostsProps) {
   const router = useRouter();
   const pb = usePocketBase();
   const { user } = useAuth();
@@ -81,7 +81,7 @@ export default function Posts({ signupEnabled }: PostsProps) {
   }, [isLoading, hasNextPage, entry, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <Layout signupEnabled={signupEnabled}>
+    <Layout signUpEnabled={signUpEnabled}>
       <Stack align="stretch" maw={450} m="0 auto">
         {data?.pages.map((p) => (
           <>

--- a/src/pages/sign-up.tsx
+++ b/src/pages/sign-up.tsx
@@ -131,7 +131,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
   const props = withEnv({});
 
   if (
-    !props.signupEnabled &&
+    !props.signUpEnabled &&
     !authMethods.usernamePassword &&
     !authMethods.emailPassword
   ) {

--- a/src/pages/users/[id].tsx
+++ b/src/pages/users/[id].tsx
@@ -1,7 +1,6 @@
 import Layout from "@/components/layout";
 import PostCard from "@/components/postCard";
 import { useCreatePost } from "@/hooks/useCreatePost";
-import { usePasteFiles } from "@/hooks/usePasteFiles";
 import { usePocketBase } from "@/pocketbase";
 import { useAuth } from "@/pocketbase/auth";
 import { Post } from "@/pocketbase/models";
@@ -74,11 +73,6 @@ export default function Posts({ signUpEnabled }: PostsProps) {
       router.push("/posts/" + post.id);
     });
 
-  usePasteFiles({
-    acceptTypes: MEDIA_MIME_TYPE,
-    onPaste: (files) => authenticatedUser && createPost(files),
-  });
-
   const { ref, entry } = useIntersection();
 
   useEffect(() => {
@@ -90,7 +84,10 @@ export default function Posts({ signUpEnabled }: PostsProps) {
   }, [isLoading, hasNextPage, entry, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <Layout signUpEnabled={signUpEnabled}>
+    <Layout
+      signUpEnabled={signUpEnabled}
+      onFiles={(files) => authenticatedUser && createPost(files)}
+    >
       <Stack align="stretch" maw={450} m="0 auto">
         {userData && <Title>Posts by {userData.username}</Title>}
         {data?.pages.map((p) => (

--- a/src/pages/users/[id].tsx
+++ b/src/pages/users/[id].tsx
@@ -15,10 +15,10 @@ import { useEffect } from "react";
 import { useInfiniteQuery, useQuery } from "react-query";
 
 interface PostsProps {
-  signupEnabled: boolean;
+  signUpEnabled: boolean;
 }
 
-export default function Posts({ signupEnabled }: PostsProps) {
+export default function Posts({ signUpEnabled }: PostsProps) {
   const router = useRouter();
 
   const { id } = router.query;
@@ -90,7 +90,7 @@ export default function Posts({ signupEnabled }: PostsProps) {
   }, [isLoading, hasNextPage, entry, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <Layout signupEnabled={signupEnabled}>
+    <Layout signUpEnabled={signUpEnabled}>
       <Stack align="stretch" maw={450} m="0 auto">
         {userData && <Title>Posts by {userData.username}</Title>}
         {data?.pages.map((p) => (

--- a/src/pocketbase/auth.ts
+++ b/src/pocketbase/auth.ts
@@ -1,4 +1,3 @@
-import { Admin, Record } from "pocketbase";
 import { useEffect, useState } from "react";
 import { usePocketBase } from "./context";
 
@@ -8,6 +7,15 @@ export const useAuth = () => {
   const [user, setUser] = useState(pb.authStore.model);
 
   useEffect(() => {
+    pb.authStore.isValid &&
+      pb
+        .collection("users")
+        .authRefresh()
+        .then((record) => setUser(record.record))
+        .catch(() => {
+          pb.authStore.clear();
+          setUser(null);
+        });
     pb.authStore.onChange((_, model) => {
       setUser(model);
     });

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,11 +1,14 @@
 import { pocketBaseUrl } from "../pocketbase";
 
-export const withEnv = <T>(
-  props: T
-): T & { signupEnabled: boolean; pocketbaseUrl?: string } =>
+interface ShareMeEnv {
+  signUpEnabled: boolean;
+  pocketbaseUrl?: string;
+}
+
+export const withEnv = <T>(props: T): T & ShareMeEnv =>
   pocketBaseUrl({
     ...props,
-    signupEnabled: process.env.SIGNUP_ENABLED
+    signUpEnabled: process.env.SIGNUP_ENABLED
       ? process.env.SIGNUP_ENABLED === "true"
       : true,
   });


### PR DESCRIPTION
- Implement a full-page dropzone to create posts from anywhere.
- Refactor `usePasteFiles()` to `Layout` and use `onFiles` `Layout` prop in pages.
- Add `[NSFW]` to page titles for mature posts.
- Add a Create Post page with title, public and NSFW settings.