### PR TITLE
feat: Detect MIME Type from File Uploads

### DIFF
--- a/server/pkg/apis/files.go
+++ b/server/pkg/apis/files.go
@@ -99,7 +99,7 @@ func RegisterFileRoutes(e *core.ServeEvent) error {
 				formFiles, ok := form.File["files"]
 
 				if !ok {
-					return apis.NewApiError(http.StatusBadRequest, "Either the file or files form body must be set.", nil)
+					return apis.NewApiError(http.StatusBadRequest, "Either the file or files form fields must be set.", nil)
 				}
 
 				for _, f := range formFiles {

--- a/server/pkg/apis/files.go
+++ b/server/pkg/apis/files.go
@@ -82,7 +82,7 @@ func RegisterFileRoutes(e *core.ServeEvent) error {
 
 			ff, err := c.FormFile("file")
 
-			if ff != nil && err != nil {
+			if ff != nil && err == nil {
 				file, err := newFile(e.App, files, record, ff)
 
 				if err != nil {


### PR DESCRIPTION
Closes #30.

- Detect MIME type from file headers or extension in `/api/posts` handler.
- Fix support for `file` form field.
- Update error messages.